### PR TITLE
build: add semantic release

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,13 +1,17 @@
-name: Android - Demo App Tagged Release
+name: Liquid Auth - Android - Release
 
 on:
   push:
-    tags:
-      - 'v*'
+    # TODO: rename trunk to main
+    branches: [ 'release/*', 'develop' ]
 jobs:
   build:
     permissions:
+      issues: write
       contents: write
+      packages: write
+      pull-requests: write
+      id-token: write
     name: Build
     runs-on: ubuntu-latest
     steps:
@@ -22,22 +26,21 @@ jobs:
         uses: gradle/gradle-build-action@v2
       - name: Build with Gradle
         run: ./gradlew build
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install
+        run: npm install --save @semantic-release/changelog @semantic-release/git @semantic-release/github
+      - name: Semantic Release
+        run: npx semantic-release --dry-run
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Merge Release -> Main
+        uses: devmasx/merge-branch@854d3ac71ed1e9deb668e0074781b81fdd6e771f
+        if: github.ref == 'refs/heads/release/1.x'
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Debug Release ${{ github.ref }}
-          prerelease: true
-      - name: Upload Debug APK
-        id: upload_release_asset
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: './demo/build/outputs/apk/debug/demo-debug.apk'
-          asset_name: fido2-debug.apk
-          asset_content_type: application/vnd.android.package-archive
+          type: now
+          from_branch: release/1.x
+          # TODO rename trunk to main
+          target_branch: develop
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,35 @@
+{
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/changelog",
+    [
+      "@semantic-release/git",
+      {
+        "assets": [
+          "CHANGELOG.md"
+        ],
+        "message": "chore(release): [skip ci] Liquid Auth \n\n${nextRelease.notes}"
+      }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "successComment": false,
+        "assets": [
+          {
+            "path": "./demo/build/outputs/apk/debug/demo-debug.apk",
+            "label": "fido2-debug.apk"
+          }
+        ]
+      }
+    ]
+  ],
+  "branches": [
+    "release/*",
+    {
+      "name": "develop",
+      "prerelease": "canary"
+    }
+  ]
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
     id("org.jetbrains.kotlin.android") version "1.9.21" apply false
     id("com.google.dagger.hilt.android") version "2.47" apply false
     id("com.android.library") version "8.1.0" apply false
+    `maven-publish`
 }

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+before_install:
+   - sdk install java 17.0.11-jbr
+   - sdk use java 17.0.11-jbr

--- a/liquid/build.gradle.kts
+++ b/liquid/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.kapt")
     id("dagger.hilt.android.plugin")
+    `maven-publish`
 }
 
 android {
@@ -23,17 +24,33 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     buildFeatures {
         buildConfig = true
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
 }
 
+publishing {
+    repositories {
+        maven {
+            url = uri("https://github.com/algorandfoundation/liquid-auth-android")
+        }
+    }
+    publications {
+        register<MavenPublication>("release") {
+            groupId = "foundation.algorand"
+            artifactId = "auth"
+            afterEvaluate {
+                from(components["release"])
+            }
+        }
+    }
+}
 dependencies {
     // AlgoSDK
     implementation("com.algorand:algosdk:2.4.0")


### PR DESCRIPTION
# ℹ Overview

- adds semantic release in dry-run mode

Example Releases: https://github.com/PhearZero/liquid-auth-android/releases

### ✅ Acceptance:
<!-- Use [X] to mark as completed -->

- [X] Conventional Commits
