### PR TITLE
feat: replace requestId double with UUID v7

### DIFF
--- a/liquid/build.gradle.kts
+++ b/liquid/build.gradle.kts
@@ -81,6 +81,9 @@ dependencies {
     implementation("com.squareup.okhttp3:okhttp:$okhttpVersion")
     implementation("ru.gildor.coroutines:kotlin-coroutines-okhttp:1.0")
 
+    // UUID Generator
+    implementation("com.fasterxml.uuid:java-uuid-generator:5.1.0")
+
     // Dev Dependencies
     testImplementation("junit:junit:4.13.2")
     testImplementation("io.mockk:mockk:1.12.0")

--- a/liquid/src/main/java/foundation/algorand/auth/connect/AuthMessage.kt
+++ b/liquid/src/main/java/foundation/algorand/auth/connect/AuthMessage.kt
@@ -16,7 +16,7 @@ private fun Uri.findParameterValue(parameterName: String): String? {
 }
 class AuthMessage @Inject constructor(
     var origin: String,
-    val requestId: Double
+    val requestId: String
 ) {
 
     companion object {
@@ -24,7 +24,7 @@ class AuthMessage @Inject constructor(
         fun fromUri(uri: Uri): AuthMessage {
             Log.d(TAG, "fromUri($uri)")
             val origin = "https://${uri.host}"
-            val requestId = uri.findParameterValue("requestId")!!.toDouble()
+            val requestId = uri.findParameterValue("requestId").toString()
             return AuthMessage(origin, requestId)
         }
         /**
@@ -40,7 +40,7 @@ class AuthMessage @Inject constructor(
                 // Fallback to JSON renderer
                 val json = JSONObject(stringContents)
                 val origin = json.get("origin").toString()
-                val requestId = json.get("requestId").toString().toDouble()
+                val requestId = json.get("requestId").toString()
                 return AuthMessage(origin, requestId)
             }
         }

--- a/liquid/src/main/java/foundation/algorand/auth/connect/SignalClient.kt
+++ b/liquid/src/main/java/foundation/algorand/auth/connect/SignalClient.kt
@@ -48,7 +48,7 @@ class SignalClient @Inject constructor(
 ) : SignalInterface {
     companion object {
         const val TAG = "connect.SignalClient"
-        fun generateRequestId(): Double {
+        fun generateRequestId(): String {
             return SignalInterface.generateRequestId()
         }
     }
@@ -62,7 +62,7 @@ class SignalClient @Inject constructor(
      * Generate a random Request ID
      * @TODO: Replace with UUID
      */
-    override fun generateRequestId(): Double {
+    override fun generateRequestId(): String {
         return SignalClient.generateRequestId()
     }
 
@@ -70,7 +70,7 @@ class SignalClient @Inject constructor(
      * Generate a QR Code
      */
     override fun qrCode(
-        requestId: Double,
+        requestId: String,
         logo: Bitmap?,
         logoSize: Int?,
         color: String?,
@@ -99,7 +99,7 @@ class SignalClient @Inject constructor(
      *
      * The type parameter is used to specify the type of remote peer
      */
-    override suspend fun peer(requestId: Double, type: String, iceServers: List<PeerConnection.IceServer>?): DataChannel? {
+    override suspend fun peer(requestId: String, type: String, iceServers: List<PeerConnection.IceServer>?): DataChannel? {
         createSocket()
         return suspendCoroutine { continuation ->
             scope.launch {
@@ -230,7 +230,7 @@ class SignalClient @Inject constructor(
     }
 
     override suspend fun link(
-        requestId: Double
+        requestId: String
     ): LinkMessage {
         return suspendCoroutine { continuation ->
             val linkBody = JSONObject()

--- a/liquid/src/main/java/foundation/algorand/auth/connect/SignalInterface.kt
+++ b/liquid/src/main/java/foundation/algorand/auth/connect/SignalInterface.kt
@@ -9,13 +9,14 @@ import org.webrtc.PeerConnection
 import org.webrtc.DataChannel
 import org.webrtc.SessionDescription
 import kotlin.math.floor
+import com.fasterxml.uuid.Generators
 
-class LinkMessage(val requestId: Double, val wallet: String, val credId: String? = null) {
+class LinkMessage(val requestId: String, val wallet: String, val credId: String? = null) {
     companion object {
         const val TAG = "connect.LinkMessage"
         fun fromJson(json: String): LinkMessage {
             val data = JSONObject(json).get("data") as JSONObject
-            val requestId = data.get("requestId").toString().toDouble()
+            val requestId = data.get("requestId").toString()
             val wallet = data.get("wallet").toString()
             val credId = data.get("credId").toString()
             return LinkMessage(requestId, wallet, credId)
@@ -37,27 +38,30 @@ interface SignalInterface {
     val context: Context? // Android Context
 
     companion object {
-        fun generateRequestId(): Double {return floor(Math.random() * 1000000)}
+        fun generateRequestId(): String {
+            val uuid = Generators.timeBasedEpochRandomGenerator().generate()
+            return uuid.toString()
+        }
     }
 
     /**
      * Generate a random Request ID
      */
-    fun generateRequestId(): Double
+    fun generateRequestId(): String
 
     /**
      * Generate a QR Code
      */
-    fun qrCode(requestId: Double, logo: Bitmap?, logoSize: Int? = null, color: String? = null, backgroundColor: String? = null): Bitmap
+    fun qrCode(requestId: String, logo: Bitmap?, logoSize: Int? = null, color: String? = null, backgroundColor: String? = null): Bitmap
 
     /**
      * Top Level Peer Connection
      */
-    suspend fun peer(requestId: Double, type: String, iceServers: List<PeerConnection.IceServer>?): DataChannel?
+    suspend fun peer(requestId: String, type: String, iceServers: List<PeerConnection.IceServer>?): DataChannel?
     /**
      * Waits for a remote client to authenticate with the server
      */
-    suspend fun link(requestId: Double): LinkMessage
+    suspend fun link(requestId: String): LinkMessage
 
     /**
      * Exchange descriptions with the remote client

--- a/liquid/src/main/java/foundation/algorand/auth/connect/SignalService.kt
+++ b/liquid/src/main/java/foundation/algorand/auth/connect/SignalService.kt
@@ -122,7 +122,7 @@ class SignalService : Service() {
      * Connect to a Peer by Request ID
      */
     suspend fun peer(
-        requestId: Double,
+        requestId: String,
         type: String,
         iceServers: List<PeerConnection.IceServer>,
     ) {

--- a/liquid/src/test/java/foundation/algorand/auth/connect/AuthMessageUnitTest.kt
+++ b/liquid/src/test/java/foundation/algorand/auth/connect/AuthMessageUnitTest.kt
@@ -21,7 +21,7 @@ class AuthMessageUnitTest {
         val origin = "https://localhost:3000"
         val requestId = SignalClient.generateRequestId()
         val message = AuthMessage.fromString("{\"requestId\":\"$requestId\", \"origin\":\"$origin\"}")
-        assertEquals(requestId, message.requestId, 0.0)
+        assertEquals(requestId, message.requestId)
         assertEquals(origin, message.origin)
     }
     @Test
@@ -34,7 +34,7 @@ class AuthMessageUnitTest {
         every { Uri.parse(any()).host } returns origin.replace("liquid://", "")
         every { Uri.parse(any()).query } returns "requestId=$requestId"
         val message = AuthMessage.fromUri(Uri.parse("liquid://$origin/?requestId=$requestId"))
-        assertEquals(requestId, message.requestId, 0.0)
+        assertEquals(requestId, message.requestId)
         assertEquals(message.origin, "https://localhost")
     }
 
@@ -46,14 +46,14 @@ class AuthMessageUnitTest {
 
         // Mocks
         val barcode = mockk<Barcode>()
-        every{barcode.displayValue} returns "liquid://$origin/?requestId=$requestId"
+        every { barcode.displayValue } returns "liquid://$origin/?requestId=$requestId"
         mockkStatic(Uri::class)
         every { Uri.parse(any()).host } returns origin.replace("liquid://", "")
         every { Uri.parse(any()).query } returns "requestId=$requestId"
 
         // Parse Message
         val message = AuthMessage.fromBarcode(barcode)
-        assertEquals(requestId, message.requestId, 0.0)
+        assertEquals(requestId, message.requestId)
         assertEquals(message.origin, "https://localhost")
     }
 


### PR DESCRIPTION
# ℹ Overview

- switched requestId from double to uuid v7 based string

### 📝 Related Issues

- https://algorandfoundation.atlassian.net/browse/ENG-297
- Blocked by: algorandfoundation/liquid-auth/pull/32

### ✅ Acceptance:
<!-- Use [X] to mark as completed -->

- [x] Conventional Commits
