### PR TITLE
fix: Change priority of BouncyCastle security provider and crashes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.1.0" apply false
+    id("com.android.application") version "8.2.2" apply false
     id("org.jetbrains.kotlin.android") version "1.9.21" apply false
     id("com.google.dagger.hilt.android") version "2.47" apply false
-    id("com.android.library") version "8.1.0" apply false
+    id("com.android.library") version "8.2.2" apply false
     `maven-publish`
 }

--- a/demo/src/main/java/foundation/algorand/demo/AnswerActivity.kt
+++ b/demo/src/main/java/foundation/algorand/demo/AnswerActivity.kt
@@ -203,8 +203,9 @@ class AnswerActivity : AppCompatActivity() {
         // Set Security
         val policy = StrictMode.ThreadPolicy.Builder().permitAll().build()
         StrictMode.setThreadPolicy(policy)
+        // This allows Algorand SDK Account creation to use BouncyCastle for EdDSA
         Security.removeProvider("BC")
-        Security.insertProviderAt(BouncyCastleProvider(), 0)
+        Security.insertProviderAt(BouncyCastleProvider(), 1)
 
         // Create FIDO Client, TODO: refactor to Credential Manager
         fido2Client = Fido2ApiClient(this@AnswerActivity)
@@ -626,47 +627,53 @@ class AnswerActivity : AppCompatActivity() {
         GmsBarcodeScanning.getClient(this@AnswerActivity)
                 .startScan()
                 .addOnSuccessListener { barcode ->
-                    // Handle any scanned FIDO URI directly
-                    if (barcode.displayValue!!.startsWith("FIDO:/")) {
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                            startActivity(
-                                    Intent(Intent.ACTION_VIEW, Uri.parse(barcode.displayValue))
-                            )
-                        } else {
-                            Toast.makeText(
-                                            this@AnswerActivity,
-                                            "Android 14 Required",
-                                            Toast.LENGTH_LONG
-                                    )
-                                    .show()
-                        }
-                        // Handle Liquid Auth URI
-                    } else {
-                        // Decode Barcode Message
-                        val msg = AuthMessage.fromBarcode(barcode)
-                        viewModel.setMessage(msg)
-                        signalService!!.updateDeepLinkFlag(false)
-                        signalService?.start(
-                                msg.origin,
-                                httpClient,
-                                notifications.createNotificationBuilder(this@AnswerActivity),
-                                NotificationViewModel.SERVICE_NOTIFICATION_ID,
-                                AnswerActivity::class.java,
-                        )
-                        // Connect to Service
-                        lifecycleScope.launch {
-                            val savedCredential =
-                                    credentialRepository.getCredentialByOrigin(
-                                            this@AnswerActivity,
-                                            msg.origin
-                                    )
-                            signalClient = SignalClient(msg.origin, this@AnswerActivity, httpClient)
-                            if (savedCredential === null) {
-                                register(msg)
+                    try {
+                        // Handle any scanned FIDO URI directly
+                        if (barcode.displayValue!!.startsWith("FIDO:/")) {
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                                startActivity(
+                                        Intent(Intent.ACTION_VIEW, Uri.parse(barcode.displayValue))
+                                )
                             } else {
-                                authenticate(msg, savedCredential)
+                                Toast.makeText(
+                                                this@AnswerActivity,
+                                                "Android 14 Required",
+                                                Toast.LENGTH_LONG
+                                        )
+                                        .show()
+                            }
+                        } else {
+                            val msg = AuthMessage.fromBarcode(barcode)
+                            viewModel.setMessage(msg)
+                            signalService!!.updateDeepLinkFlag(false)
+                            signalService?.start(
+                                    msg.origin,
+                                    httpClient,
+                                    notifications.createNotificationBuilder(this@AnswerActivity),
+                                    NotificationViewModel.SERVICE_NOTIFICATION_ID,
+                                    AnswerActivity::class.java,
+                            )
+                            lifecycleScope.launch {
+                                val savedCredential =
+                                        credentialRepository.getCredentialByOrigin(
+                                                this@AnswerActivity,
+                                                msg.origin
+                                        )
+                                signalClient = SignalClient(msg.origin, this@AnswerActivity, httpClient)
+                                if (savedCredential === null) {
+                                    register(msg)
+                                } else {
+                                    authenticate(msg, savedCredential)
+                                }
                             }
                         }
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Error processing barcode: ${e.message}")
+                        Toast.makeText(
+                                this@AnswerActivity,
+                                "Invalid QR code: ${e.message}",
+                                Toast.LENGTH_LONG
+                        ).show()
                     }
                 }
                 .addOnCanceledListener {

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,5 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+# Use Java 17 for Gradle
+org.gradle.java.home=/usr/lib/jvm/temurin-17-jdk-amd64

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Dec 14 11:25:59 CST 2023
+#Fri Mar 06 21:26:58 GMT 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/liquid/src/main/java/foundation/algorand/auth/connect/AuthMessage.kt
+++ b/liquid/src/main/java/foundation/algorand/auth/connect/AuthMessage.kt
@@ -37,8 +37,14 @@ class AuthMessage @Inject constructor(
             if(stringContents.startsWith("liquid://")) {
                return fromUri(Uri.parse(stringContents))
             } else {
-                // Fallback to JSON renderer
+                // Fallback 
                 val json = JSONObject(stringContents)
+                if (!json.has("origin")) {
+                    throw IllegalArgumentException("Invalid QR code: missing 'origin' field")
+                }
+                if (!json.has("requestId")) {
+                    throw IllegalArgumentException("Invalid QR code: missing 'requestId' field")
+                }
                 val origin = json.get("origin").toString()
                 val requestId = json.get("requestId").toString()
                 return AuthMessage(origin, requestId)


### PR DESCRIPTION
Fix: BouncyCastle to take precedence of android default provider
Fix: crashes when QRCode isn't valid (found in testing while scanning non-demo qrcodes) 